### PR TITLE
Add missing dependency to hacl-star

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -23,6 +23,7 @@
    (bls12-381 (= "6.1.0"))
    (ppx_yojson_conv (>= "v0.16.0"))
    ppx_yojson_conv_lib
+   hacl-star
    hex
    ppxlib)
  (version "1.0.0"))

--- a/zukelang.opam
+++ b/zukelang.opam
@@ -15,6 +15,7 @@ depends: [
   "bls12-381" {= "6.1.0"}
   "ppx_yojson_conv" {>= "v0.16.0"}
   "ppx_yojson_conv_lib"
+  "hacl-star"
   "hex"
   "ppxlib"
   "odoc" {with-doc}


### PR DESCRIPTION
This change was needed to make `opam install` pass.